### PR TITLE
[Documentation] replace id with agent node - command only

### DIFF
--- a/references/cli-reference/all-flags.md
+++ b/references/cli-reference/all-flags.md
@@ -1049,14 +1049,14 @@ Flags:
   -h, --help   help for help
 ```
 
-## ID[​](http://localhost:3000/dev/cli-reference/all-flags#id) <a href="#id" id="id"></a>
+## Agent node[​](http://localhost:3000/dev/cli-reference/all-flags#id) <a href="#id" id="id"></a>
 
-The `bacalhau id` command shows bacalhau node id info.
+The `bacalhau agent node` command shows bacalhau node id info.
 
 Usage:
 
 ```bash
-bacalhau id [flags]
+bacalhau agent node [flags]
 ```
 
 ```bash

--- a/setting-up/running-node/auth.md
+++ b/setting-up/running-node/auth.md
@@ -37,10 +37,10 @@ curl -sL https://raw.githubusercontent.com/bacalhau-project/bacalhau/main/pkg/au
 bacalhau config set Auth.Methods '\{Method: ClientKey, Policy: \{Type: challenge, PolicyPath: ~/.bacalhau/challenge_ns_no_anon.rego\}\}'
 ```
 
-Then, modify the `allowed_clients` variable in `challange_ns_no_anon.rego` to include acceptable client IDs, found by running `bacalhau id`.
+Then, modify the `allowed_clients` variable in `challange_ns_no_anon.rego` to include acceptable client IDs, found by running `bacalhau agent node`.
 
 ```
-bacalhau id | jq -rc .ClientID
+bacalhau agent node | jq -rc .ClientID
 ```
 
 Once the node is restarted, only keys in the allowed list will be able to access any API.


### PR DESCRIPTION
Update commands on all documentation for v1.4.0
`bacalhau id → bacalhau agent node`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the command to display Bacalhau node ID to `bacalhau agent node`.
  
- **Documentation**
  - Revised CLI reference documentation to reflect the new command `bacalhau agent node`.
  - Updated access control configuration instructions to incorporate the new command for retrieving client IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->