### PR TITLE
[Documentation] replace validate with job validate - command only

### DIFF
--- a/references/cli-reference/all-flags.md
+++ b/references/cli-reference/all-flags.md
@@ -1935,14 +1935,14 @@ bacalhau serve --peer env --private-internal-ipfs=false
 bacalhau serve --webui
 ```
 
-## Validate[​](http://localhost:3000/dev/cli-reference/all-flags#validate) <a href="#validate" id="validate"></a>
+## Job validate[​](http://localhost:3000/dev/cli-reference/all-flags#validate) <a href="#validate" id="validate"></a>
 
-The `bacalhau validate` command allows you to validate job files in JSON or YAML formats before sending them to the Bacalhau system. It is used to confirm that the structure and contents of the job description file conform to the expected format.
+The `bacalhau job validate` command allows you to validate job files in JSON or YAML formats before sending them to the Bacalhau system. It is used to confirm that the structure and contents of the job description file conform to the expected format.
 
 Usage:
 
 ```bash
-bacalhau validate [flags]
+bacalhau job validate [flags]
 ```
 
 ```bash
@@ -1956,7 +1956,7 @@ Flags:
 To Validate the `job.yaml` file, run:
 
 ```bash
-bacalhau validate ./job.yaml
+bacalhau job validate ./job.yaml
 ```
 
 ## Version[​](http://localhost:3000/dev/cli-reference/all-flags#version-1) <a href="#version-1" id="version-1"></a>


### PR DESCRIPTION
Update commands on all documentation for v1.4.0
`bacalhau validate → bacalhau job validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated CLI command `bacalhau validate` to `bacalhau job validate` for validating job files in JSON or YAML formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->