### PR TITLE
[Documentation] replace cancel with job stop - command only

### DIFF
--- a/getting-started/architecture.md
+++ b/getting-started/architecture.md
@@ -365,7 +365,7 @@ The Bacalhau client provides the user with tools to monitor and manage the execu
 {% tabs %}
 {% tab title="CLI" %}
 ```bash
-bacalhau cancel [id] [flags]
+bacalhau job stop [id] [flags]
 ```
 
 You can use the command with [appropriate flags](../references/cli-reference/all-flags.md#cancel) to cancel a job that was previously submitted and stop it running if it has not yet completed.

--- a/references/cli-reference/all-flags.md
+++ b/references/cli-reference/all-flags.md
@@ -248,14 +248,14 @@ Expected Output:
 }
 ```
 
-## Cancel[​](http://localhost:3000/dev/cli-reference/all-flags#cancel) <a href="#cancel" id="cancel"></a>
+## Job stop[​](http://localhost:3000/dev/cli-reference/all-flags#cancel) <a href="#cancel" id="cancel"></a>
 
 The `bacalhau cancel` command cancels a job that was previously submitted and stops it running if it has not yet completed.
 
 Usage:
 
 ```bash
-bacalhau cancel [id] [flags]
+bacalhau job stop [id] [flags]
 ```
 
 ```bash
@@ -269,13 +269,13 @@ Flags:
 To cancel a previously submitted job, run:
 
 ```bash
- bacalhau cancel 51225160-807e-48b8-88c9-28311c7899e1
+ bacalhau job stop 51225160-807e-48b8-88c9-28311c7899e1
 ```
 
 To cancel a job using a short ID, run:
 
 ```bash
- bacalhau cancel 51225160
+ bacalhau job stop 51225160
 ```
 
 ## Completion[​](http://localhost:3000/dev/cli-reference/all-flags#completion) <a href="#completion" id="completion"></a>


### PR DESCRIPTION
Update commands on all documentation for v1.4.0
`bacalhau cancel → bacalhau job stop`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated command instructions from `bacalhau cancel` to `bacalhau job stop` in the architecture and CLI reference documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->