### PR TITLE
[Documentation] replace create with job run - command only

### DIFF
--- a/getting-started/architecture.md
+++ b/getting-started/architecture.md
@@ -113,7 +113,7 @@ Bacalhau provides an interface to interact with the server via a REST API. Bacal
 {% tabs %}
 {% tab title="CLI" %}
 ```sh
-bacalhau create [flags]
+bacalhau job run [flags]
 ```
 
 You can use the command with [appropriate flags](../references/cli-reference/all-flags.md) to create a job in Bacalhau using JSON and YAML formats.

--- a/references/cli-reference/all-flags.md
+++ b/references/cli-reference/all-flags.md
@@ -600,14 +600,14 @@ node:
         port: 9999
 ```
 
-## Create[​](http://localhost:3000/dev/cli-reference/all-flags#create) <a href="#create" id="create"></a>
+## Job run[​](http://localhost:3000/dev/cli-reference/all-flags#create) <a href="#create" id="create"></a>
 
 The `bacalhau create` command is used to submit a job to the network in a declarative way by writing a jobspec instead of writing a command. JSON and YAML formats are accepted.
 
 Usage:
 
 ```bash
-bacalhau create [flags]
+bacalhau job run [flags]
 ```
 
 ```bash
@@ -631,7 +631,7 @@ Flags:
 1. To create a job using the data in `job.yaml`, run:
 
 ```bash
-bacalhau create ./job.yaml
+bacalhau job run ./job.yaml
 ```
 
 2. To create a new job from an already executed job, run:


### PR DESCRIPTION
Update commands on all documentation for v1.4.0
`bacalhau create → bacalhau job run`