### PR TITLE
[Documentation] replace describe with job describe - command only

### DIFF
--- a/dev/cli-reference/all-flags.md
+++ b/dev/cli-reference/all-flags.md
@@ -98,7 +98,7 @@ Examples:
   bacalhau create ./job.yaml
 
   # Create a new job from an already executed job
-  bacalhau describe 6e51df50 | bacalhau create -
+  bacalhau job describe 6e51df50 | bacalhau create -
 ```
 
 An example job in YAML format:
@@ -196,7 +196,7 @@ An example UCAN Invocation that runs a WebAssembly job might look like:
 Full description of a job, in yaml format. Use 'bacalhau list' to get a list of all ids. Short form and long form of the job id are accepted.
 
 Usage:
-  bacalhau describe [id] [flags]
+  bacalhau job describe [id] [flags]
 
 Flags:
   -h, --help             help for describe
@@ -209,13 +209,13 @@ Flags:
 ```
 Examples:
   # Describe a job with the full ID
-  bacalhau describe e3f8c209-d683-4a41-b840-f09b88d087b9
+  bacalhau job describe e3f8c209-d683-4a41-b840-f09b88d087b9
 
   # Describe a job with the a shortened ID
-  bacalhau describe 47805f5c
+  bacalhau job describe 47805f5c
 
   # Describe a job and include all server and local events
-  bacalhau describe --include-events b6ad164a
+  bacalhau job describe --include-events b6ad164a
 ```
 
 ## Docker run

--- a/dev/debugging/debugging-general.md
+++ b/dev/debugging/debugging-general.md
@@ -31,7 +31,7 @@ CREATED   ID        JOB                      STATE      VERIFIED  PUBLISHED
 
 ## 2. Inspecting the Status of the Job
 
-When you first suspect that your job has failed, the first thing you should do is inspect the status. The `bacalhau describe $JOB_ID` command presents everything that is known about a job from the perspective of the network.
+When you first suspect that your job has failed, the first thing you should do is inspect the status. The `bacalhau job describe $JOB_ID` command presents everything that is known about a job from the perspective of the network.
 
 Look through the `Shards` of the job and see if any of them have a `State` of `Error`. The `RunOutput` field provides the juicy details of what went wrong.
 

--- a/examples/data-engineering/blockchain-etl/index.md
+++ b/examples/data-engineering/blockchain-etl/index.md
@@ -175,11 +175,11 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/data-engineering/csv-to-avro-or-parquet/index.md
+++ b/examples/data-engineering/csv-to-avro-or-parquet/index.md
@@ -190,7 +190,7 @@ When a job is submitted, Bacalhau prints out the related `job_id`. We store that
 ```
 
 ```
-env: JOB_ID=bacalhau describe 71ecde0e-dac3-4c8d-bf2e-7a92cc54425e
+env: JOB_ID=bacalhau job describe 71ecde0e-dac3-4c8d-bf2e-7a92cc54425e
 ```
 
 ## Checking the State of your Jobs
@@ -211,11 +211,11 @@ bacalhau list --id-filter={JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe {JOB_ID}
+bacalhau job describe {JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/data-engineering/image-processing/index.md
+++ b/examples/data-engineering/image-processing/index.md
@@ -69,11 +69,11 @@ bacalhau list --id-filter=${JOB_ID} --no-style
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/data-engineering/index-1.md
+++ b/examples/data-engineering/index-1.md
@@ -160,10 +160,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/examples/data-engineering/index-2.md
+++ b/examples/data-engineering/index-2.md
@@ -359,10 +359,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/examples/data-engineering/index-3.md
+++ b/examples/data-engineering/index-3.md
@@ -93,10 +93,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`:
+**Job information**: You can find out more information about your job by using `bacalhau job describe`:
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/data-engineering/index-4.md
+++ b/examples/data-engineering/index-4.md
@@ -254,10 +254,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/examples/data-engineering/index-5.md
+++ b/examples/data-engineering/index-5.md
@@ -97,10 +97,10 @@ bacalhau list --id-filter ${JOB_ID} --no-style
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/examples/data-engineering/index.md
+++ b/examples/data-engineering/index.md
@@ -151,10 +151,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.
@@ -250,10 +250,10 @@ When a job is submitted, Bacalhau prints out the related `job_id`. We store that
 bacalhau list --id-filter ${JOB_ID} --wide
 ```
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/data-engineering/oceanography-conversion/index.md
+++ b/examples/data-engineering/oceanography-conversion/index.md
@@ -255,11 +255,11 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/data-engineering/simple-parallel-workloads/index.md
+++ b/examples/data-engineering/simple-parallel-workloads/index.md
@@ -51,11 +51,11 @@ bacalhau list --id-filter=${JOB_ID} --no-style
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/Stable-Diffusion-CKPT-Inference/index.md
+++ b/examples/model-inference/Stable-Diffusion-CKPT-Inference/index.md
@@ -162,11 +162,11 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/easyocr/index.md
+++ b/examples/model-inference/easyocr/index.md
@@ -157,11 +157,11 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/index-1.md
+++ b/examples/model-inference/index-1.md
@@ -104,10 +104,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`:
+**Job information**: You can find out more information about your job by using `bacalhau job describe`:
 
 ```
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/index-2.md
+++ b/examples/model-inference/index-2.md
@@ -352,10 +352,10 @@ When it says `Completed`, that means the job is done, and we can get the results
 
 ### Job information[​](http://localhost:3000/examples/model-inference/Openai-Whisper/#job-information) <a href="#job-information" id="job-information"></a>
 
-You can find out more information about your job by using `bacalhau describe`.
+You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 ### Job download[​](http://localhost:3000/examples/model-inference/Openai-Whisper/#job-download) <a href="#job-download" id="job-download"></a>

--- a/examples/model-inference/index-3.md
+++ b/examples/model-inference/index-3.md
@@ -275,10 +275,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/index-4.md
+++ b/examples/model-inference/index-4.md
@@ -179,10 +179,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`:
+**Job information**: You can find out more information about your job by using `bacalhau job describe`:
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/index-5.md
+++ b/examples/model-inference/index-5.md
@@ -108,10 +108,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`:
+**Job information**: You can find out more information about your job by using `bacalhau job describe`:
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/index-6.md
+++ b/examples/model-inference/index-6.md
@@ -190,10 +190,10 @@ When it says `Completed`, that means the job is done, and we can get the results
 
 ### Job information[​](http://localhost:3000/examples/model-inference/StyleGAN3/#job-information) <a href="#job-information" id="job-information"></a>
 
-You can find out more information about your job by using `bacalhau describe`.
+You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 ### Job download[​](http://localhost:3000/examples/model-inference/StyleGAN3/#job-download) <a href="#job-download" id="job-download"></a>

--- a/examples/model-inference/index.md
+++ b/examples/model-inference/index.md
@@ -200,10 +200,10 @@ When it says `Completed`, that means the job is done, and we can get the results
 
 ### Job information[​](http://localhost:3000/examples/model-inference/EasyOCR/#job-information) <a href="#job-information" id="job-information"></a>
 
-You can find out more information about your job by using `bacalhau describe`.
+You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 ### Job download[​](http://localhost:3000/examples/model-inference/EasyOCR/#job-download) <a href="#job-download" id="job-download"></a>

--- a/examples/model-inference/object-detection-yolo5/index.md
+++ b/examples/model-inference/object-detection-yolo5/index.md
@@ -67,11 +67,11 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/openai-whisper/index.md
+++ b/examples/model-inference/openai-whisper/index.md
@@ -319,11 +319,11 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/stable-diffusion-checkpoint-inference.md
+++ b/examples/model-inference/stable-diffusion-checkpoint-inference.md
@@ -165,10 +165,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`:
+**Job information**: You can find out more information about your job by using `bacalhau job describe`:
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/stable-diffusion-cpu/index.md
+++ b/examples/model-inference/stable-diffusion-cpu/index.md
@@ -179,7 +179,7 @@ To find out more information about your job, run the following command:
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 If you see that the job has completed and there are no errors, then you can download the results with the following command:

--- a/examples/model-inference/stable-diffusion-gpu/index.md
+++ b/examples/model-inference/stable-diffusion-gpu/index.md
@@ -264,11 +264,11 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-inference/stylegan3/index.md
+++ b/examples/model-inference/stylegan3/index.md
@@ -148,11 +148,11 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-training/Stable-Diffusion-Dreambooth/index.md
+++ b/examples/model-training/Stable-Diffusion-Dreambooth/index.md
@@ -394,11 +394,11 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 In the next steps, we will be doing inference on the finetuned model
@@ -482,11 +482,11 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-training/index-1.md
+++ b/examples/model-training/index-1.md
@@ -235,10 +235,10 @@ When it says `Completed`, that means the job is done, and we can get the results
 
 ### Job information[​](http://localhost:3000/examples/model-training/Training-Tensorflow-Model/#job-information) <a href="#job-information" id="job-information"></a>
 
-You can find out more information about your job by using `bacalhau describe`.
+You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 ### Job download[​](http://localhost:3000/examples/model-training/Training-Tensorflow-Model/#job-download) <a href="#job-download" id="job-download"></a>

--- a/examples/model-training/index.md
+++ b/examples/model-training/index.md
@@ -137,10 +137,10 @@ When it says `Completed`, that means the job is done, and we can get the results
 
 ### Job information[​](http://localhost:3000/examples/model-training/Training-Pytorch-Model/#job-information) <a href="#job-information" id="job-information"></a>
 
-You can find out more information about your job by using `bacalhau describe`.
+You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 ### Job download[​](http://localhost:3000/examples/model-training/Training-Pytorch-Model/#job-download) <a href="#job-download" id="job-download"></a>

--- a/examples/model-training/stable-diffusion-dreambooth-finetuning.md
+++ b/examples/model-training/stable-diffusion-dreambooth-finetuning.md
@@ -419,10 +419,10 @@ When it says `Completed`, that means the job is done, and we can get the results
 
 ### Job information[​](http://localhost:3000/examples/model-training/Stable-Diffusion-Dreambooth/#job-information) <a href="#job-information" id="job-information"></a>
 
-You can find out more information about your job by using `bacalhau describe`.
+You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 ### Job download[​](http://localhost:3000/examples/model-training/Stable-Diffusion-Dreambooth/#job-download) <a href="#job-download" id="job-download"></a>

--- a/examples/model-training/training-pytorch-model/index.md
+++ b/examples/model-training/training-pytorch-model/index.md
@@ -97,11 +97,11 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-* **Job information**: You can find out more information about your job by using `bacalhau describe`.
+* **Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 * **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory and downloaded our job output to be stored in that directory.

--- a/examples/model-training/training-tensorflow-model/index.md
+++ b/examples/model-training/training-tensorflow-model/index.md
@@ -198,7 +198,7 @@ To find out more information about your job, run the following command:
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 ```bash

--- a/examples/molecular-dynamics/index-1.md
+++ b/examples/molecular-dynamics/index-1.md
@@ -90,10 +90,10 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/examples/molecular-dynamics/index-2.md
+++ b/examples/molecular-dynamics/index-2.md
@@ -237,10 +237,10 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/examples/molecular-dynamics/index-3.md
+++ b/examples/molecular-dynamics/index-3.md
@@ -106,10 +106,10 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/examples/molecular-dynamics/index-4.md
+++ b/examples/molecular-dynamics/index-4.md
@@ -120,10 +120,10 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/examples/molecular-dynamics/index-5.md
+++ b/examples/molecular-dynamics/index-5.md
@@ -227,10 +227,10 @@ bacalhau list --id-filter=${JOB_ID} --no-style
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/getting-started/architecture.md
+++ b/getting-started/architecture.md
@@ -297,7 +297,7 @@ To describe a specific job, inserting the ID to the CLI or API gives back an ove
 {% tabs %}
 {% tab title="CLI" %}
 ```bash
-bacalhau describe [id] [flags]
+bacalhau job describe [id] [flags]
 ```
 
 You can use the command with [appropriate flags](../references/cli-reference/all-flags.md) to get a full description of a job in yaml format.

--- a/getting-started/create-private-network.md
+++ b/getting-started/create-private-network.md
@@ -172,7 +172,7 @@ To download the results, execute:
         bacalhau get ddbfa358-d663-4f54-804e-598c53dbb969
         
 To get more details about the run, execute: 
-        bacalhau describe ddbfa358-d663-4f54-804e-598c53dbb969 
+        bacalhau job describe ddbfa358-d663-4f54-804e-598c53dbb969 
 ```
 
 You will be able to see the job execution logs on the compute node:

--- a/getting-started/docker-workload-onboarding.md
+++ b/getting-started/docker-workload-onboarding.md
@@ -189,7 +189,7 @@ bacalhau list --id-filter JOB_ID
 To get more information on your job, you can run the following command.
 
 ```shell
-bacalhau describe JOB_ID
+bacalhau job describe JOB_ID
 ```
 
 To download your job, run.

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -87,7 +87,7 @@ To download the results, execute:
     bacalhau get f8e7789d-8e76-4e6c-8e71-436e2d76c72e
 
 To get more details about the run, execute:
-    bacalhau describe f8e7789d-8e76-4e6c-8e71-436e2d76c72e
+    bacalhau job describe f8e7789d-8e76-4e6c-8e71-436e2d76c72e
 ```
 
 After the above command is run, the job is submitted to the public network, which processes the job and Bacalhau prints out the related job id:
@@ -154,10 +154,10 @@ For a comprehensive list of flags you can pass to the list command check out [th
 
 #### Step 3.2 - Job information:
 
-You can find out more information about your job by using `bacalhau describe`.
+You can find out more information about your job by using `bacalhau job describe`.
 
 ```shell
-bacalhau describe 9d20bbad
+bacalhau job describe 9d20bbad
 ```
 
 Let's take a look at the results of the command execution in the terminal:

--- a/references/cli-reference/all-flags.md
+++ b/references/cli-reference/all-flags.md
@@ -637,7 +637,7 @@ bacalhau create ./job.yaml
 2. To create a new job from an already executed job, run:
 
 ```bash
-bacalhau describe 6e51df50 | bacalhau create
+bacalhau job describe 6e51df50 | bacalhau create
 ```
 
 ### YAML format[​](http://localhost:3000/dev/cli-reference/all-flags#yaml-format) <a href="#yaml-format" id="yaml-format"></a>
@@ -737,12 +737,12 @@ Using a UCAN Invocation object allows you to customize the parameters of job exe
 
 ## Describe[​](http://localhost:3000/dev/cli-reference/all-flags#describe) <a href="#describe" id="describe"></a>
 
-The `bacalhau describe` command provides a full description of a job in YAML format. Short form and long form of the job id are accepted.
+The `bacalhau job describe` command provides a full description of a job in YAML format. Short form and long form of the job id are accepted.
 
 Usage:
 
 ```bash
-bacalhau describe [id] [flags]
+bacalhau job describe [id] [flags]
 ```
 
 ```bash
@@ -758,19 +758,19 @@ Flags:
 1. To describe a job with the full ID, run:
 
 ```bash
-bacalhau describe e3f8c209-d683-4a41-b840-f09b88d087b9
+bacalhau job describe e3f8c209-d683-4a41-b840-f09b88d087b9
 ```
 
 2. To describe a job with the shortened ID, run:
 
 ```bash
-bacalhau describe e3f8c209
+bacalhau job describe e3f8c209
 ```
 
 3. To describe a job and include all server and local events, run:
 
 ```bash
-bacalhau describe e3f8c209 --include-events  
+bacalhau job describe e3f8c209 --include-events  
 ```
 
 ## Devstack[​](http://localhost:3000/dev/cli-reference/all-flags#devstack) <a href="#devstack" id="devstack"></a>
@@ -1083,7 +1083,7 @@ Usage:
 
 Available Commands:
 
-### describe[​](http://localhost:3000/dev/cli-reference/all-flags#describe-1) <a href="#describe-1" id="describe-1"></a>
+### Job describe[​](http://localhost:3000/dev/cli-reference/all-flags#describe-1) <a href="#describe-1" id="describe-1"></a>
 
 ```bash
 bacalhau job describe [id] [flags]

--- a/references/debugging/debugging-general.md
+++ b/references/debugging/debugging-general.md
@@ -29,7 +29,7 @@ CREATED   ID        JOB                      STATE      VERIFIED  PUBLISHED
 
 ## 2. Inspecting the Status of the Job
 
-When you first suspect that your job has failed, the first thing you should do is inspect the status. The `bacalhau describe $JOB_ID` command presents everything that is known about a job from the perspective of the network.
+When you first suspect that your job has failed, the first thing you should do is inspect the status. The `bacalhau job describe $JOB_ID` command presents everything that is known about a job from the perspective of the network.
 
 Look through the `Shards` of the job and see if any of them have a `State` of `Error`. The `RunOutput` field provides the juicy details of what went wrong.
 

--- a/setting-up/data-ingestion/from-url.md
+++ b/setting-up/data-ingestion/from-url.md
@@ -40,10 +40,10 @@ bacalhau list $JOB_ID --output=json | jq '.[0].Status.JobState.Nodes[] | .Shards
 
 When the job status is `Published` or `Completed`, that means the job is done, and we can get the results using the job ID.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe  $JOB_ID 
+bacalhau job describe  $JOB_ID 
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we removed a directory in case it was present before, created it and downloaded our job output to be stored in that directory.

--- a/setting-up/data-ingestion/s3.md
+++ b/setting-up/data-ingestion/s3.md
@@ -40,10 +40,10 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we remove the results directory if it exists, create it again and download our job output to be stored in that directory.
@@ -94,7 +94,7 @@ sudo apt install jq
 To extract the CIDs from output JSON, execute following:
 
 ```bash
-bacalhau describe ${JOB_ID} --json \
+bacalhau job describe ${JOB_ID} --json \
 | jq -r '.State.Executions[].PublishedResults.CID | select (. != null)'
 ```
 

--- a/setting-up/workload-onboarding/CUDA/README.md
+++ b/setting-up/workload-onboarding/CUDA/README.md
@@ -133,13 +133,13 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/CUDA/index.md
+++ b/setting-up/workload-onboarding/CUDA/index.md
@@ -127,11 +127,11 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/container/docker-workload-onboarding.md
+++ b/setting-up/workload-onboarding/container/docker-workload-onboarding.md
@@ -179,7 +179,7 @@ $ bacalhau list --id-filter JOB_ID
 To get more information on your job,run:
 
 ```shell
-$ bacalhau describe JOB_ID
+$ bacalhau job describe JOB_ID
 ```
 
 To download your job, run:

--- a/setting-up/workload-onboarding/container/index.md
+++ b/setting-up/workload-onboarding/container/index.md
@@ -136,7 +136,7 @@ docker run -t ghcr.io/bacalhau-project/bacalhau:latest \
 
 When it says `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 docker run -t ghcr.io/bacalhau-project/bacalhau:latest \

--- a/setting-up/workload-onboarding/index-1.md
+++ b/setting-up/workload-onboarding/index-1.md
@@ -99,10 +99,10 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/index-2.md
+++ b/setting-up/workload-onboarding/index-2.md
@@ -63,10 +63,10 @@ bacalhau list --id-filter=${JOB_ID} --no-style
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/index-4.md
+++ b/setting-up/workload-onboarding/index-4.md
@@ -144,10 +144,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/python/Python-Custom-Container/index.md
+++ b/setting-up/workload-onboarding/python/Python-Custom-Container/index.md
@@ -321,12 +321,12 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/python/building-and-running-custom-python-container.md
+++ b/setting-up/workload-onboarding/python/building-and-running-custom-python-container.md
@@ -288,10 +288,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/python/index-3.md
+++ b/setting-up/workload-onboarding/python/index-3.md
@@ -51,10 +51,10 @@ bacalhau list --id-filter=${JOB_ID} --no-style
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`:
+**Job information**: You can find out more information about your job by using `bacalhau job describe`:
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.
@@ -165,10 +165,10 @@ bacalhau list --id-filter=${JOB_ID} --no-style
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/python/python-pandas/index.md
+++ b/setting-up/workload-onboarding/python/python-pandas/index.md
@@ -123,12 +123,12 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/python/running-a-python-script.md
+++ b/setting-up/workload-onboarding/python/running-a-python-script.md
@@ -94,10 +94,10 @@ bacalhau list --id-filter ${JOB_ID} --no-style
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/python/running-pandas-on-bacalhau.md
+++ b/setting-up/workload-onboarding/python/running-pandas-on-bacalhau.md
@@ -99,10 +99,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/python/trivial-python/index.md
+++ b/setting-up/workload-onboarding/python/trivial-python/index.md
@@ -82,11 +82,11 @@ bacalhau list --id-filter ${JOB_ID} --no-style
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/r-custom-docker-prophet/index.md
+++ b/setting-up/workload-onboarding/r-custom-docker-prophet/index.md
@@ -205,10 +205,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.

--- a/setting-up/workload-onboarding/r-custom-docker-prophet/running-a-simple-r-script-on-bacalhau.md
+++ b/setting-up/workload-onboarding/r-custom-docker-prophet/running-a-simple-r-script-on-bacalhau.md
@@ -91,10 +91,10 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe  ${JOB_ID}
+bacalhau job describe  ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.
@@ -114,10 +114,10 @@ cat results/stdout
 
 #### Futureproofing your R Scripts[​](http://localhost:3000/setting-up/workload-onboarding/r-hello-world/#futureproofing-your-r-scripts) <a href="#futureproofing-your-r-scripts" id="futureproofing-your-r-scripts"></a>
 
-You can generate the job request using `bacalhau describe` with the `--spec` flag. This will allow you to re-run that job in the future:
+You can generate the job request using `bacalhau job describe` with the `--spec` flag. This will allow you to re-run that job in the future:
 
 ```bash
-bacalhau describe ${JOB_ID} --spec > job.yaml
+bacalhau job describe ${JOB_ID} --spec > job.yaml
 ```
 
 ```bash

--- a/setting-up/workload-onboarding/r-hello-world/index.md
+++ b/setting-up/workload-onboarding/r-hello-world/index.md
@@ -82,12 +82,12 @@ bacalhau list --id-filter ${JOB_ID}
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 
 ```bash
 %%bash
-bacalhau describe  ${JOB_ID}
+bacalhau job describe  ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.
@@ -110,12 +110,12 @@ cat results/stdout
 
 ### Futureproofing your R Scripts
 
-You can generate the job request using `bacalhau describe` with the `--spec` flag. This will allow you to re-run that job in the future:
+You can generate the job request using `bacalhau job describe` with the `--spec` flag. This will allow you to re-run that job in the future:
 
 
 ```bash
 %%bash
-bacalhau describe ${JOB_ID} --spec > job.yaml
+bacalhau job describe ${JOB_ID} --spec > job.yaml
 ```
 
 

--- a/setting-up/workload-onboarding/run-cuda-programs-on-bacalhau.md
+++ b/setting-up/workload-onboarding/run-cuda-programs-on-bacalhau.md
@@ -108,10 +108,10 @@ bacalhau list --id-filter ${JOB_ID} --wide
 
 When it says `Published` or `Completed`, that means the job is done, and we can get the results.
 
-**Job information**: You can find out more information about your job by using `bacalhau describe`.
+**Job information**: You can find out more information about your job by using `bacalhau job describe`.
 
 ```bash
-bacalhau describe ${JOB_ID}
+bacalhau job describe ${JOB_ID}
 ```
 
 **Job download**: You can download your job results directly by using `bacalhau get`. Alternatively, you can choose to create a directory to store your results. In the command below, we created a directory (`results`) and downloaded our job output to be stored in that directory.


### PR DESCRIPTION
Update commands on all documentation for v1.4.0
`bacalhau describe → bacalhau job describe`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Renamed the command `bacalhau describe` to `bacalhau job describe` for improved clarity and consistency across all documentation.

- **Documentation**
  - Updated all relevant documentation to reflect the new command syntax, ensuring consistency in usage instructions and examples.

These changes enhance the user experience by making command usage more intuitive and consistent throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->