### PR TITLE
[Documentation] replace logs with job logs - command only

### DIFF
--- a/examples/model-inference/index-7.md
+++ b/examples/model-inference/index-7.md
@@ -149,10 +149,10 @@ When the job is submitted Bacalhau prints out the related job id. We store that 
 
 ### Viewing the Output[​](http://localhost:3000/examples/model-inference/S3-Model-Inference/#viewing-the-output) <a href="#viewing-the-output" id="viewing-the-output"></a>
 
-Use the `bacalhau logs` command to view the job output, since the script prints the result of execution to the stdout:
+Use the `bacalhau job logs` command to view the job output, since the script prints the result of execution to the stdout:
 
 ```bash
-bacalhau logs ${JOB_ID}
+bacalhau job logs ${JOB_ID}
 
 Predicted class: 0
 ```

--- a/examples/model-inference/s3-model-inference/index.md
+++ b/examples/model-inference/s3-model-inference/index.md
@@ -147,5 +147,5 @@ The job has been submitted and Bacalhau has printed out the related job id. We s
 
 ```bash
 %%bash
-bacalhau logs ${JOB_ID}
+bacalhau job logs ${JOB_ID}
 ```

--- a/getting-started/architecture.md
+++ b/getting-started/architecture.md
@@ -403,7 +403,7 @@ You can use [Job History API Documentation](../references/api/jobs.md#job-histor
 ### Job Logs
 
 ```shell
-bacalhau logs [flags] [id]
+bacalhau job logs [flags] [id]
 ```
 
 You can use this [command](../references/cli-reference/all-flags.md#logs) to retrieve the log output (stdout, and stderr) from a job. If the job is still running it is possible to follow the logs after the previously generated logs are retrieved.

--- a/references/cli-reference/all-flags.md
+++ b/references/cli-reference/all-flags.md
@@ -1616,14 +1616,14 @@ bacalhau list
 bacalhau list --output json
 ```
 
-## Logs[​](http://localhost:3000/dev/cli-reference/all-flags#logs-1) <a href="#logs-1" id="logs-1"></a>
+## Job logs[​](http://localhost:3000/dev/cli-reference/all-flags#logs-1) <a href="#logs-1" id="logs-1"></a>
 
-The `bacalhau logs` command retrieves the log output (stdout, and stderr) from a job. If the job is still running it is possible to follow the logs after the previously generated logs are retrieved.
+The `bacalhau job logs` command retrieves the log output (stdout, and stderr) from a job. If the job is still running it is possible to follow the logs after the previously generated logs are retrieved.
 
 Usage:
 
 ```bash
-bacalhau logs [id] [flags]
+bacalhau job logs [id] [flags]
 ```
 
 ```bash
@@ -1637,13 +1637,13 @@ Flags:
 1. To follow logs for a previously submitted job, run:
 
 ```bash
-bacalhau logs -f 51225160-807e-48b8-88c9-28311c7899e1
+bacalhau job logs -f 51225160-807e-48b8-88c9-28311c7899e1
 ```
 
 2. To retrieve the log output with a short ID, but don't follow any newly generated logs,run:
 
 ```bash
-bacalhau logs ebd9bf2f
+bacalhau job logs ebd9bf2f
 ```
 
 ## Node[​](http://localhost:3000/dev/cli-reference/all-flags#node-1) <a href="#node-1" id="node-1"></a>


### PR DESCRIPTION
Update commands on all documentation for v1.4.0
`bacalhau logs → bacalhau job logs`
