### PR TITLE
Add more WASM engine examples

### DIFF
--- a/cli-api/specifications/engines/wasm.md
+++ b/cli-api/specifications/engines/wasm.md
@@ -10,9 +10,9 @@ The WASM Engine in Bacalhau allows tasks to be executed in a WebAssembly environ
 * **EnvironmentVariables** `(map[string]string: <optional>)`: A mapping of environment variable keys to their values, made available within the executing WASM environment.
 * **ImportModules** `(`[`InputSource`](../job/input-source.md)`[] : optional)`: An array of InputSources pointing to additional WASM modules. The exports from these modules will be available as imports to the EntryModule, enabling modular and reusable WASM code.
 
-### Example
+## Examples
 
-Here’s a sample configuration of the WASM Engine within a task, expressed in YAML:
+### Using S3 bucket
 
 ```yaml
 Engine:
@@ -39,3 +39,43 @@ Params:
 ```
 
 In this example, the task is configured to run in a WASM environment. The EntryModule is fetched from an S3 bucket, the entrypoint is `_start`, and parameters and environment variables are passed into the WASM environment. Additionally, an ImportModule is loaded from a local directory, making its exports available to the EntryModule.
+
+## Using Local Provider
+
+```yaml
+Engine:
+  Type: wasm
+  Params:
+    EntryModule:
+      Source:
+        Type: "localDirectory"
+        Params:
+          SourcePath: "/app/main.wasm"
+      Target: "/main.wasm"
+    Entrypoint: "start_app"
+    Parameters:
+      - "--assets"
+      - "/app/data"
+InputSources:
+  - Source:
+      Type: "urlDownload"
+      Params:
+        URL: "https://example.com/data/file.txt"
+    Target: "/app/data"
+```
+
+In this example, the main WASM module is fetched from the local file system on the compute node. The entrypoint function is `start_app`, and it is given two arguments `"--assets"` and `"/app/data"`. Additionally, the WASM environment has access to `/app/data/file.txt` file downloaded from the given URL.
+
+{% hint style="info" %}
+Parameters are passed to the WASM module as command-line arguments. To access these arguments in your WASM module, you'll need to implement the appropriate code based on your programming language. For example, in Rust, you can retrieve the parameters as follows:
+
+```rust
+use std::env;
+
+fn _start() {
+  let args: Vec<String> = env::args().collect();
+  // &args[0] is the program name, &args[1] is the first parameter
+}
+```
+{% endhint %}
+


### PR DESCRIPTION
* Added a realistic example of a WASM job.
* Clarified how `Parameters` are passed to the entrypoint function  