### PR TITLE
Remove cross-references from llms.txt

### DIFF
--- a/content/community/social-media.md
+++ b/content/community/social-media.md
@@ -4,23 +4,19 @@ sidebar_position: 10
 
 # Social Media
 
-Bacalhau has a presence on all major social media networks, so you can follow us on your favorite sites.
+Bacalhau has a presence on major social media networks. Follow us to stay updated!
 
 ## YouTube
 
-The [Bacalhau](https://www.youtube.com/@bacalhauproject) and [Expanso](https://www.youtube.com/@ExpansoIO) YouTube channels are home to a wealth of information about the Bacalhau project — everything from developer demos, educational videos, events, etc. You can explore and learn more about Bacalhau.
+The [Bacalhau YouTube channel](https://www.youtube.com/@bacalhauproject) is home to developer demos, educational videos, events, and more. Explore and learn more about distributed compute with Bacalhau.
 
 ## Blog
 
-Our blog contains product updates, company news, and educational content on how you can leverage Bacalhau and the Compute over Data ecosystem [Bacalhau Blog](https://bacalhau.substack.com/). Also, you can subscribe to our blog and receive the latest news straight to your inbox.
+Our blog contains product updates, project news, and educational content on how you can leverage Bacalhau and the Compute over Data ecosystem: [Bacalhau Blog](https://bacalhau.substack.com/). Subscribe to receive the latest news straight to your inbox.
 
 ## X (Formerly Twitter)
 
-You can follow our X accounts [@BacalhauProject](https://x.com/BacalhauProject) and [@ExpansoIO](https://x.com/ExpansoIO) to get Bacalhau news, product updates, etc in tweet-sized bites.
-
-## LinkedIn
-
-Connect with us on [LinkedIn](https://www.linkedin.com/company/expanso-io) to stay informed about the latest news, industry trends, and exclusive job opportunities!
+Follow [@BacalhauProject](https://x.com/BacalhauProject) for Bacalhau news, product updates, and community highlights.
 
 ## Need Support?
 

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,9 @@
     "libp2p",
     "duckdb",
     "myvalue",
-    "oom"
+    "oom",
+    "llms",
+    "ETL",
+    "ELT"
   ]
 }

--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -151,7 +151,7 @@ Submit a new job for execution.
 
 **Request Body**:
 
-- [**Job**](../specifications/job/): JSON definition of the job.
+- [**Job**](/docs/specifications/job/): JSON definition of the job.
 
 **Response**:
 

--- a/docs/specifications/other/state.md
+++ b/docs/specifications/other/state.md
@@ -2,7 +2,7 @@
 
 ## `State` Structure Specification
 
-Within Bacalhau, the `State` structure is designed to represent the status or state of an object (like a [`Job`](../job/)), coupled with a human-readable message for added context. Below is a breakdown of the structure:
+Within Bacalhau, the `State` structure is designed to represent the status or state of an object (like a [`Job`](/docs/specifications/job/)), coupled with a human-readable message for added context. Below is a breakdown of the structure:
 
 ### `State` Parameters
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -31,13 +31,22 @@ bacalhau job list
 - **Distributed**: Scale from laptop to thousands of nodes
 - **Open Source**: Apache 2.0 licensed, community-driven
 
+## Use Cases
+
+- **Log Processing**: Process logs at the source before aggregation
+- **ML Inference**: Run models close to data for low latency
+- **Data Pipelines**: ETL/ELT without moving large datasets
+- **Edge Computing**: Deploy compute to edge locations
+
 ## Resources
 
 - GitHub: https://github.com/bacalhau-project/bacalhau
-- Discord: https://bit.ly/bacalhau-project-slack
+- Slack: https://bit.ly/bacalhau-project-slack
 - Website: https://bacalhau.org
 
-## Related
+## Quick Facts
 
-- [Expanso Platform](https://docs.expanso.io/llms.txt): Enterprise features
-- [Examples](https://examples.expanso.io/llms.txt): Code examples
+- License: Apache 2.0 (fully open source)
+- Language: Go
+- Supported Runtimes: Docker, WebAssembly
+- Category: Distributed Compute


### PR DESCRIPTION
## Summary

Bacalhau content = 100% Bacalhau.

## Changes

1. **llms.txt**: Removed links to unrelated projects in 'Related' section
2. **Social media page**: Removed mixed social accounts - now links only to Bacalhau YouTube, Twitter, etc.

## Principle

Cross-references — even "check out our related X account" — teach LLMs to associate products that should be discussed separately.