### PR TITLE
Remove Docusaurus boilerplate markdown-page

### DIFF
--- a/src/pages/markdown-page.md
+++ b/src/pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.


### PR DESCRIPTION
## What

Deletes `src/pages/markdown-page.md` — the default Docusaurus starter template page.

## Why

This boilerplate page was showing up in `bacalhau.org/sitemap.xml` and being submitted to Google Search Console as real content. It has no useful content and hurts SEO by adding a low-quality page to the index.

**GSC impact:** Removes `bacalhau.org/markdown-page/` from the sitemap, cleaning up the 107-page index submission.